### PR TITLE
Improve foliage on tree models seen in the last section

### DIFF
--- a/media/model/mapmodel/ard/vegetation/bigtree-noanim/iqm.cfg
+++ b/media/model/mapmodel/ard/vegetation/bigtree-noanim/iqm.cfg
@@ -11,6 +11,6 @@ iqmbumpmap leaf "../leaf01_n.png"
 iqmnoclip leaves 1
 
 mdlspec -1
-mdlcullface 0
+mdlcullface -1
 mdlalphatest 0.3
 mdlellipsecollide 1

--- a/media/model/mapmodel/ard/vegetation/bigtree/iqm.cfg
+++ b/media/model/mapmodel/ard/vegetation/bigtree/iqm.cfg
@@ -13,6 +13,6 @@ iqmanim mapmodel "../tree.iqm" 4
 iqmnoclip leaves 1
 
 mdlspec -1
-mdlcullface 0
+mdlcullface -1
 mdlalphatest 0.3
 mdlellipsecollide 1

--- a/media/model/mapmodel/ard/vegetation/mediumtree1/iqm.cfg
+++ b/media/model/mapmodel/ard/vegetation/mediumtree1/iqm.cfg
@@ -13,6 +13,6 @@ iqmanim mapmodel "../tree.iqm" 2
 iqmnoclip leaves 1
 
 mdlspec -1
-mdlcullface 0
+mdlcullface -1
 mdlalphatest 0.3
 mdlellipsecollide 1

--- a/media/model/mapmodel/ard/vegetation/mediumtree2/iqm.cfg
+++ b/media/model/mapmodel/ard/vegetation/mediumtree2/iqm.cfg
@@ -13,6 +13,6 @@ iqmanim mapmodel "../tree.iqm" 2
 iqmnoclip leaves 1
 
 mdlspec -1
-mdlcullface 0
+mdlcullface -1
 mdlalphatest 0.3
 mdlellipsecollide 1

--- a/media/model/mapmodel/ard/vegetation/smalltree/iqm.cfg
+++ b/media/model/mapmodel/ard/vegetation/smalltree/iqm.cfg
@@ -13,6 +13,6 @@ iqmanim mapmodel "../tree.iqm" 2
 iqmnoclip leaves 1
 
 mdlspec -1
-mdlcullface 0
+mdlcullface -1
 mdlalphatest 0.3
 mdlellipsecollide 1


### PR DESCRIPTION
Change the `mdlcullface` value to `-1` for better effect on the tree foliage, which will result less flat.